### PR TITLE
 fix: wrong plural 'informations'

### DIFF
--- a/docs/src/content/docs/configuration.mdx
+++ b/docs/src/content/docs/configuration.mdx
@@ -51,7 +51,7 @@ starlightKbd({
 **Type:** [`StarlightKbdTypesConfig`](#types-configuration)
 
 A list of keyboard types supported in your documentation.
-Check the ["Types configuration"](#types-configuration) section for more informations.
+Check the ["Types configuration"](#types-configuration) section for more information.
 
 ## Types configuration
 

--- a/packages/starlight-kbd/libs/config.ts
+++ b/packages/starlight-kbd/libs/config.ts
@@ -66,7 +66,7 @@ export function validateConfig(userConfig: unknown): StarlightKbdConfig {
 
 ${z.prettifyError(config.error)}
 `,
-      `See the error report above for more informations.\n\nIf you believe this is a bug, please file an issue at https://github.com/HiDeoo/starlight-kbd/issues/new/choose`,
+      `See the error report above for more information.\n\nIf you believe this is a bug, please file an issue at https://github.com/HiDeoo/starlight-kbd/issues/new/choose`,
     )
   }
 


### PR DESCRIPTION
The documentation mentions `informations`, but there is no plural for this word.
This PR corrects this. 